### PR TITLE
`azurerm_mssql_server`: Fix documentation

### DIFF
--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -91,6 +91,18 @@ An `identity` block supports the following:
 
 * `user_assigned_identity_ids` - (Optional) Specifies a list of User Assigned Identity IDs to be assigned. Required if `type` is `UserAssigned` and should be combined with `primary_user_assigned_identity_id`.
 
+---
+
+An `azuread_administrator` block supports the following:
+
+* `login_username` - (Required)  The login username of the Azure AD Administrator of this SQL Server.
+
+* `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Server.
+
+* `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Server.
+
+* `azuread_authentication_only` - (Optional) Specifies whether only AD Users and administrators (like `azuread_administrator.0.login_username`) can be used to login or also local database users (like `administrator_login`).
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -110,18 +122,6 @@ The following attributes are exported:
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Server.
 
 -> You can access the Principal ID via `azurerm_mssql_server.example.identity.0.principal_id` and the Tenant ID via `azurerm_mssql_server.example.identity.0.tenant_id`
-
----
-
-An `azuread_administrator` block supports the following:
-
-* `login_username` - (Required)  The login username of the Azure AD Administrator of this SQL Server.
-
-* `object_id` - (Required) The object id of the Azure AD Administrator of this SQL Server.
-
-* `tenant_id` - (Optional) The tenant id of the Azure AD Administrator of this SQL Server.
-
-* `azuread_authentication_only` - (Optional) Specifies whether only AD Users and administrators (like `azuread_administrator.0.login_username`) can be used to login or also local database users (like `administrator_login`).
 
 ### Timeouts
 


### PR DESCRIPTION
Hello,

Actually in the documentation of the resource `azurerm_mssql_server`, the `azuread_administrator` documentation block is part of **Attributes References** instead of **Arguments References**.

This PR fix this.

Thanks in advance